### PR TITLE
🎨 Palette: Enhance Room List Selection UX

### DIFF
--- a/common.css
+++ b/common.css
@@ -186,6 +186,13 @@ kbd {
   color: yellow;
 }
 
+/* Selected room in lobby list */
+#room_list li.selected {
+  background: #444;
+  color: yellow;
+  border-left: 4px solid yellow;
+}
+
 #room_list li .count {
   background: #555;
   padding: 1px 6px;

--- a/lobby-ui.mjs
+++ b/lobby-ui.mjs
@@ -2,7 +2,11 @@ import { Dom } from './dom.mjs';
 
 export function renderRoomList(rooms) {
   const list = Dom.get('room_list');
+  const input = Dom.get('input_room');
   if (!list) return; // Guard in case DOM isn't ready
+
+  const currentRoom = input ? input.value : null;
+
   list.innerHTML = '';
   rooms.forEach(room => {
     const li = document.createElement('li');
@@ -11,9 +15,21 @@ export function renderRoomList(rooms) {
     li.setAttribute('role', 'button');
     li.setAttribute('aria-label', `Join room ${room.id}, ${room.count} players`);
 
+    if (currentRoom === room.id) {
+      li.classList.add('selected');
+      li.setAttribute('aria-current', 'true');
+    }
+
     const selectRoom = () => {
-      const input = Dom.get('input_room');
       if (input) input.value = room.id;
+
+      // Update visual selection
+      Array.from(list.children).forEach(child => {
+        child.classList.remove('selected');
+        child.removeAttribute('aria-current');
+      });
+      li.classList.add('selected');
+      li.setAttribute('aria-current', 'true');
     };
 
     li.onclick = selectRoom;

--- a/test/ux_room_list.test.mjs
+++ b/test/ux_room_list.test.mjs
@@ -8,10 +8,11 @@ class MockElement {
     this.id = tagOrId;
     this.tagName = (tagOrId || 'div').toUpperCase();
     this.style = {};
+    this._classes = new Set();
     this.classList = {
-      add: (cls) => {},
-      remove: (cls) => {},
-      contains: (cls) => false,
+      add: (cls) => { this._classes.add(cls); this.className = Array.from(this._classes).join(' '); },
+      remove: (cls) => { this._classes.delete(cls); this.className = Array.from(this._classes).join(' '); },
+      contains: (cls) => this._classes.has(cls),
     };
     this.className = '';
     this.innerHTML = '';
@@ -32,6 +33,10 @@ class MockElement {
 
   getAttribute(name) {
     return this.attributes[name];
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
   }
 
   addEventListener(type, fn) {
@@ -141,7 +146,7 @@ describe('Lobby UX', async () => {
     assert.strictEqual(global.mocks['input_room'].value, 'room1');
   });
 
-    it('should NOT select room on other keys', () => {
+  it('should NOT select room on other keys', () => {
     const rooms = [{ id: 'room1', count: 2 }];
     global.mocks['room_list'] = new MockElement('ul');
     global.mocks['input_room'] = new MockElement('input');
@@ -160,5 +165,58 @@ describe('Lobby UX', async () => {
 
     assert.strictEqual(prevented, false, 'Should NOT prevent default on other keys');
     assert.strictEqual(global.mocks['input_room'].value, 'original', 'Should NOT change value');
+  });
+
+  it('should visually select room matching input value on render', () => {
+    const rooms = [
+      { id: 'room1', count: 2 },
+      { id: 'room2', count: 0 }
+    ];
+    global.mocks['room_list'] = new MockElement('ul');
+    global.mocks['input_room'] = new MockElement('input');
+    global.mocks['input_room'].value = 'room1'; // Pre-selected
+
+    renderRoomList(rooms);
+
+    const list = global.mocks['room_list'];
+    const li1 = list.children[0];
+    const li2 = list.children[1];
+
+    assert.ok(li1.classList.contains('selected'), 'Matching room should have selected class');
+    assert.strictEqual(li1.getAttribute('aria-current'), 'true', 'Matching room should have aria-current');
+
+    assert.strictEqual(li2.classList.contains('selected'), false, 'Non-matching room should NOT have selected class');
+    assert.strictEqual(li2.getAttribute('aria-current'), undefined, 'Non-matching room should NOT have aria-current');
+  });
+
+  it('should update visual selection on click', () => {
+    const rooms = [
+      { id: 'room1', count: 2 },
+      { id: 'room2', count: 0 }
+    ];
+    global.mocks['room_list'] = new MockElement('ul');
+    global.mocks['input_room'] = new MockElement('input');
+    global.mocks['input_room'].value = 'room1';
+
+    renderRoomList(rooms);
+
+    const list = global.mocks['room_list'];
+    const li1 = list.children[0];
+    const li2 = list.children[1];
+
+    // Initial state check
+    assert.ok(li1.classList.contains('selected'));
+    assert.strictEqual(li1.getAttribute('aria-current'), 'true');
+
+    // Click second room
+    li2.trigger('click');
+
+    // Verify update
+    assert.strictEqual(li1.classList.contains('selected'), false, 'Old selection should be removed');
+    assert.strictEqual(li1.getAttribute('aria-current'), undefined, 'Old aria-current should be removed');
+
+    assert.ok(li2.classList.contains('selected'), 'New selection should be added');
+    assert.strictEqual(li2.getAttribute('aria-current'), 'true', 'New aria-current should be added');
+    assert.strictEqual(global.mocks['input_room'].value, 'room2', 'Input value should update');
   });
 });


### PR DESCRIPTION
Added visual and semantic feedback when selecting a room in the lobby. The selected room now has a yellow border and background highlight, and uses `aria-current="true"` for screen readers. This ensures the selection state in the list remains consistent with the input field, even when the list re-renders.

---
*PR created automatically by Jules for task [9471062465013763677](https://jules.google.com/task/9471062465013763677) started by @cliztech*