### PR TITLE
UX: Add empty state for room list

### DIFF
--- a/common.css
+++ b/common.css
@@ -201,6 +201,20 @@ kbd {
   color: white;
 }
 
+#room_list li.empty-state {
+  font-style: italic;
+  color: #999;
+  text-align: center;
+  cursor: default;
+  display: block;
+  border: none;
+}
+
+#room_list li.empty-state:hover {
+  background: transparent;
+  color: #999;
+}
+
 #btn_join {
   margin-top: 1em;
   font-size: 1.5em;

--- a/lobby-ui.mjs
+++ b/lobby-ui.mjs
@@ -8,6 +8,15 @@ export function renderRoomList(rooms) {
   const currentRoom = input ? input.value : null;
 
   list.innerHTML = '';
+
+  if (rooms.length === 0) {
+    const li = document.createElement('li');
+    li.innerHTML = "No signals detected...";
+    li.classList.add('empty-state');
+    list.appendChild(li);
+    return;
+  }
+
   rooms.forEach(room => {
     const li = document.createElement('li');
     li.innerHTML = `<span>${room.id}</span><span class="count">${room.count}</span>`;

--- a/test/ux_room_list.test.mjs
+++ b/test/ux_room_list.test.mjs
@@ -219,4 +219,19 @@ describe('Lobby UX', async () => {
     assert.strictEqual(li2.getAttribute('aria-current'), 'true', 'New aria-current should be added');
     assert.strictEqual(global.mocks['input_room'].value, 'room2', 'Input value should update');
   });
+
+  it('should render empty state when no rooms are available', () => {
+    const rooms = [];
+    global.mocks['room_list'] = new MockElement('ul');
+
+    renderRoomList(rooms);
+
+    const list = global.mocks['room_list'];
+    assert.strictEqual(list.children.length, 1);
+
+    const li = list.children[0];
+    assert.strictEqual(li.tagName, 'LI');
+    assert.ok(li.classList.contains('empty-state'), 'Should have empty-state class');
+    assert.strictEqual(li.innerHTML, 'No signals detected...');
+  });
 });


### PR DESCRIPTION
Added a "No signals detected..." empty state to the room list in the lobby. This provides better user feedback than an empty list. The implementation uses a specific CSS class `.empty-state` for styling and is covered by a new unit test. Validated with Playwright.

---
*PR created automatically by Jules for task [1118586715673815580](https://jules.google.com/task/1118586715673815580) started by @cliztech*