### PR TITLE
🎨 Palette: Add 'Enter' shortcut for game chat

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-02-15 - Implicit Form Submission
 **Learning:** For inputs like chat that need "Enter to submit" behavior, using a semantic `<form>` with a hidden `submit` button is more robust and accessible than custom `keydown` listeners. It handles mobile keyboards ("Go" button) and focus management natively.
 **Action:** Wrap single-input UI patterns in `<form>` tags and listen for the `submit` event instead of `keydown`.
+
+## 2026-02-27 - Global Contextual Shortcuts
+**Learning:** Implementing a global key listener (e.g., "Enter" to chat) that intelligently respects the current focus state (ignoring other inputs) and application state (only when game is active) allows for seamless mode switching without explicit UI toggles.
+**Action:** Use global `keydown` listeners with strict target/state checks to shortcut access to primary secondary actions (like chat or search).

--- a/v4.final.html
+++ b/v4.final.html
@@ -80,6 +80,7 @@
   <div id='instructions'>
     <p>Use <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd> or <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> to drive.</p>
     <p>Press <kbd>R</kbd> to restart.</p>
+    <p>Press <kbd>Enter</kbd> to chat.</p>
   </div>
 
   <div id="racer" tabindex="-1" aria-label="Game screen">

--- a/v4.final.js
+++ b/v4.final.js
@@ -112,6 +112,19 @@ import { KEY, COLORS, BACKGROUND, SPRITES, GAME_CONFIG, RACE_STATE } from './con
       }
     });
 
+    // Global shortcut to focus chat
+    Dom.on(document, 'keydown', function(ev) {
+      if (ev.key === 'Enter' && !ev.defaultPrevented) {
+        const target = ev.target;
+        const isInteractive = ['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON', 'A'].includes(target.tagName);
+        // Only focus chat if we're in-game (login hidden) and not busy with another control
+        if (!isInteractive && Dom.get('login').style.display === 'none') {
+           ev.preventDefault();
+           Dom.get('chat_input').focus();
+        }
+      }
+    });
+
     Dom.on('login', 'submit', function(ev) {
       ev.preventDefault();
       const name = Dom.get('input_name').value || 'Racer X';


### PR DESCRIPTION
🎨 Palette has added a small but delightful UX improvement:
Users can now press `Enter` to immediately focus the chat input while racing, without needing to reach for the mouse.

**What changed:**
- Added `<p>Press <kbd>Enter</kbd> to chat.</p>` to the instructions panel.
- Added a smart global key listener that detects the `Enter` key.
- The listener is context-aware: it only focuses chat if the game is active (login hidden) and the user isn't already typing in another field.

**Why:**
- Allows for seamless trash-talking while driving! 🏎️💨
- Improves keyboard accessibility by removing the need to tab through the interface or use a mouse.

**Verification:**
- Verified via Playwright script `verify_chat.py` that the instruction appears and the shortcut works as intended.
- Ran `ux_input.test.mjs` to ensure no regressions in game input handling.


---
*PR created automatically by Jules for task [11244773431552764679](https://jules.google.com/task/11244773431552764679) started by @cliztech*