### PR TITLE
🎨 Palette: Improve Settings Focus & Game Navigation

### DIFF
--- a/common.css
+++ b/common.css
@@ -34,6 +34,7 @@ a:hover {
 }
 
 /* Consistent focus styles for all interactive elements */
+#racer:focus-visible,
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,

--- a/test/ux_tweak_focus.test.mjs
+++ b/test/ux_tweak_focus.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { setupTweakUI } from '../tweak-ui.mjs';
+
+test('tweak UI should not blur on change', () => {
+  let blurCalled = false;
+  const handlers = {};
+
+  const mockDom = {
+    get: (id) => ({
+      value: 1000,
+      getAttribute: () => 1000,
+      selectedIndex: 0,
+      options: [{ value: 'high' }],
+      blur: () => { blurCalled = true; }
+    }),
+    on: (id, event, handler) => {
+      if (!handlers[id]) handlers[id] = {};
+      handlers[id][event] = handler;
+    },
+    blur: (ev) => {
+      blurCalled = true;
+    }
+  };
+
+  const mockUtil = {
+    limit: (v) => v,
+    toInt: (v) => parseInt(v, 10)
+  };
+
+  const callbacks = { reset: () => {} };
+
+  setupTweakUI(callbacks, { Dom: mockDom, Util: mockUtil });
+
+  // Test 'lanes' (SELECT element, uses 'change')
+  const evLanes = {
+    target: {
+      options: [{ value: '3' }],
+      selectedIndex: 0,
+      blur: () => { blurCalled = true; }
+    }
+  };
+
+  if (handlers['lanes'] && handlers['lanes']['change']) {
+    handlers['lanes']['change'](evLanes);
+    assert.equal(blurCalled, false, 'Dom.blur should not be called on lanes change');
+  } else {
+    throw new Error('Change handler not registered for lanes');
+  }
+
+  // Test 'roadWidth' (INPUT range, should NOT have change handler or should not blur)
+  // In my implementation, I removed the change handler for roadWidth entirely.
+  if (handlers['roadWidth'] && handlers['roadWidth']['change']) {
+     const evRoad = { target: { blur: () => { blurCalled = true; } } };
+     handlers['roadWidth']['change'](evRoad);
+     assert.equal(blurCalled, false, 'Dom.blur should not be called on roadWidth change');
+  } else {
+     // If no handler, then obviously no blur happens on change event via our code.
+     assert.ok(true, 'No change handler for roadWidth, implicitly safe');
+  }
+
+});

--- a/tweak-ui.mjs
+++ b/tweak-ui.mjs
@@ -12,24 +12,16 @@ export function setupTweakUI(callbacks, { Dom = defaultDom, Util = defaultUtil }
       case 'low':    w = 480;  h = 360; break;
     }
     reset({ width: w, height: h });
-    Dom.blur(ev);
   });
 
-  Dom.on('lanes',          'change', function(ev) { Dom.blur(ev); reset({ lanes:         ev.target.options[ev.target.selectedIndex].value }); });
+  Dom.on('lanes',          'change', function(ev) { reset({ lanes:         ev.target.options[ev.target.selectedIndex].value }); });
   Dom.on('roadWidth',      'input',  function(ev) { reset({ roadWidth:     Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('roadWidth',      'change', function(ev) { Dom.blur(ev); });
   Dom.on('cameraHeight',   'input',  function(ev) { reset({ cameraHeight:  Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('cameraHeight',   'change', function(ev) { Dom.blur(ev); });
   Dom.on('drawDistance',   'input',  function(ev) { reset({ drawDistance:  Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('drawDistance',   'change', function(ev) { Dom.blur(ev); });
   Dom.on('fieldOfView',    'input',  function(ev) { reset({ fieldOfView:   Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('fieldOfView',    'change', function(ev) { Dom.blur(ev); });
   Dom.on('fogDensity',     'input',  function(ev) { reset({ fogDensity:    Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('fogDensity',     'change', function(ev) { Dom.blur(ev); });
   Dom.on('simulatedLatency', 'input', function(ev) { reset({ simulatedLatency: Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('simulatedLatency', 'change', function(ev) { Dom.blur(ev); });
   Dom.on('smoothing',        'input', function(ev) { reset({ smoothing:        Util.limit(Util.toInt(ev.target.value), Util.toInt(ev.target.getAttribute('min')), Util.toInt(ev.target.getAttribute('max'))) }); });
-  Dom.on('smoothing',        'change', function(ev) { Dom.blur(ev); });
 }
 
 export function refreshTweakUI(state, { Dom = defaultDom } = {}) {

--- a/v4.final.html
+++ b/v4.final.html
@@ -83,7 +83,7 @@
     <p>Press <kbd>Enter</kbd> to chat.</p>
   </div>
 
-  <div id="racer" tabindex="-1" aria-label="Game screen">
+  <div id="racer" tabindex="0" aria-label="Game screen">
     <div id="hud">
       <span id="speed"            class="hud"><span id="speed_value" class="value">0</span> mph</span>
       <span id="current_lap_time" class="hud">Time: <span id="current_lap_time_value" class="value">0.0</span></span> 

--- a/v4.final.js
+++ b/v4.final.js
@@ -748,7 +748,10 @@ import { KEY, COLORS, BACKGROUND, SPRITES, GAME_CONFIG, RACE_STATE } from './con
       }
     });
 
-    Dom.on('restart', 'click', function() { reset(); });
+    Dom.on('restart', 'click', function() {
+      reset();
+      Dom.get('racer').focus();
+    });
 
     Dom.on('resetSettings', 'click', function() {
       Dom.get('resolution').value = 'high';


### PR DESCRIPTION
This PR addresses a UX friction point where changing any setting (like Road Width) would immediately drop focus, forcing keyboard users to navigate back to the control or preventing immediate verification of the change. 

It also fixes a related issue where clicking "Restart Race" left focus on the button, preventing the user from driving (WASD/Arrows) until they clicked the canvas.

Changes:
1.  **Tweak UI**: Removed `Dom.blur(ev)` from event handlers.
2.  **Game Container**: Made `#racer` focusable (`tabindex="0"`) and added focus styles.
3.  **Restart Logic**: Explicitly focus `#racer` after reset.
4.  **Verification**: Added a test case ensuring `blur` is not called on change.

---
*PR created automatically by Jules for task [6816013399824697672](https://jules.google.com/task/6816013399824697672) started by @cliztech*