### PR TITLE
Remove unsupported Aseprite exporter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ npm test     # run unit tests
 Art exports
 -----------
 
-This repo does not currently include an asset exporter or `build:art` task. Aseprite
-exports are not supported yet; add art assets directly to `/images` until a pipeline
-is introduced.
+This repo does not currently include an asset exporter or `build:art` task. Art assets
+should be added directly to `/images` until a full art pipeline is
+introduced.
 
 Incrementally built up in 4 parts:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Development
 npm ci       # install dependencies
 npm start    # launch http://localhost:8080/v4.final.html
 npm test     # run unit tests
+
 ```
+
+Art exports
+-----------
+
+This repo does not currently include an asset exporter or `build:art` task. Aseprite
+exports are not supported yet; add art assets directly to `/images` until a pipeline
+is introduced.
 
 Incrementally built up in 4 parts:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ This plan outlines the next development milestones to evolve Base Racers into a 
 - Provide **npm scripts** for dev (`npm start`), multiplayer dev server (`npm run dev:net`), and tests (`npm test`).
 
 ## Asset Pipeline
-- Set up **Aseprite + TexturePacker** (or free alternatives) for sprite atlas generation; commit source `.ase` files.
+- Set up **sprite atlas tooling** (e.g., TexturePacker or free alternatives) for sprite atlas generation; commit source art files.
 - Define **sprite slicing metadata** compatible with existing `sprites.js`; add preview thumbnails to `/images`.
 - Implement **resolution scaling** (low-res canvas scaled up with `image-rendering: pixelated`) to keep crisp edges.
 

--- a/docs/TEAM_PLAYBOOK.md
+++ b/docs/TEAM_PLAYBOOK.md
@@ -23,7 +23,7 @@ This playbook defines the skills, knowledge, leadership structure, technology ch
 
 ## 3) Core Skills and Knowledge Base
 - **Engineering**: JavaScript/TypeScript, Phaser/Canvas/WebGL, WebSocket and WebRTC patterns, server-authoritative multiplayer, deterministic/lockstep vs. client-prediction models, cryptography basics, security (XSS/CSRF, replay protection), build tooling (Vite/Webpack), CI/CD (GitHub Actions), containerization.
-- **Art**: pixel-art workflow (Aseprite/Piskel), palette discipline, sprite sheet packing, VFX timing, UI/UX for low-res displays, accessibility contrast guidelines.
+- **Art**: pixel-art workflow (Piskel or similar), palette discipline, sprite sheet packing, VFX timing, UI/UX for low-res displays, accessibility contrast guidelines.
 - **Audio**: looped track design, dynamic mixing, audio budget for web, latency minimization.
 - **Product/Design**: free-to-play ethics, progression balancing, economy design (if web3), retention/engagement metrics, live-ops cadence.
 - **QA/Performance**: profiling (FPS, memory, GC), network simulation, automated regression, cross-browser/device matrices.


### PR DESCRIPTION
## Summary
- document that art exports and `build:art` are not supported yet
- remove Aseprite-specific guidance from the roadmap and team playbook

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953841d5c0c832c9ebdb6b227c302d9)