### PR TITLE
fix stats.js variable declaration

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -7,7 +7,7 @@ var Stats = function () {
   var startTime = Date.now(), prevTime = startTime;
   var ms = 0, msMin = 1000, msMax = 0;
   var fps = 0, fpsMin = 1000, fpsMax = 0;
-  var frames = 0, mode = 0;mode
+  var frames = 0, mode = 0;
   var container = document.createElement( 'div' );
   container.id = 'stats';
   container.addEventListener( 'mousedown', function ( event ) { event.preventDefault(); setMode( ++ mode % 2 ) }, false );


### PR DESCRIPTION
## Summary
- remove stray `mode` token in stats.js declaration to ensure valid JavaScript

## Testing
- `node --check stats.js && echo 'syntax ok'`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_689ae760a45c832cbb60317baf486844)